### PR TITLE
Issue #9 Added a menu icon on navbar for smaller screen size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "ethers": "^5.7.2",
         "framer-motion": "^11.5.5",
+        "i": "^0.3.7",
         "lucide-react": "^0.441.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
@@ -3946,6 +3948,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5312,6 +5322,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "ethers": "^5.7.2",
     "framer-motion": "^11.5.5",
+    "i": "^0.3.7",
     "lucide-react": "^0.441.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { FaBars, FaTimes } from 'react-icons/fa';
 
 function Navbar({ account }) {
+  const [isOpen, setIsOpen] = useState(false); 
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen); 
+  };
+
   return (
     <nav className="bg-white shadow-lg">
       <div className="max-w-6xl mx-auto px-4">
-        <div className="flex justify-between">
+        <div className="flex justify-between items-center"> 
           <div className="flex space-x-7">
             <div>
               <Link to="/" className="flex items-center py-4 px-2">
@@ -13,16 +20,43 @@ function Navbar({ account }) {
               </Link>
             </div>
             <div className="hidden md:flex items-center space-x-1">
-              <Link to="/owner" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">Dashboard</Link>
-              <Link to="/sell" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">Sell Energy</Link>
-              <Link to="/buy" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">Buy Energy</Link>
+              <Link to="/owner" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">
+                Dashboard
+              </Link>
+              <Link to="/sell" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">
+                Sell Energy
+              </Link>
+              <Link to="/buy" className="py-4 px-2 text-gray-500 hover:text-green-500 transition duration-300">
+                Buy Energy
+              </Link>
             </div>
           </div>
-          <div className="hidden md:flex items-center space-x-3">
+
+          {/* Account info always visible */}
+          <div className="flex items-center space-x-3">
             <span className="py-2 px-2 font-medium text-gray-500 rounded hover:bg-green-500 hover:text-white transition duration-300">
               {account ? `Connected: ${account.slice(0, 6)}...${account.slice(-4)}` : 'Not Connected'}
             </span>
+
+            {/* Hamburger menu icon (only for mobile) */}
+            <div className="md:hidden flex items-center">
+              <button onClick={toggleMenu}>
+                {isOpen ? <FaTimes size={24} /> : <FaBars size={24} />} 
+              </button>
+            </div>
           </div>
+        </div>
+
+        <div className={`md:hidden ${isOpen ? 'block' : 'hidden'}`}>
+          <Link to="/owner" className="block py-2 px-4 text-sm hover:bg-green-500">
+            Dashboard
+          </Link>
+          <Link to="/sell" className="block py-2 px-4 text-sm hover:bg-green-500">
+            Sell Energy
+          </Link>
+          <Link to="/buy" className="block py-2 px-4 text-sm hover:bg-green-500">
+            Buy Energy
+          </Link>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
### Before
https://github.com/user-attachments/assets/1b16c41e-c11a-4493-90a7-75587a217769

### After
https://github.com/user-attachments/assets/a1e1ac73-66e0-4d7b-ad6b-dee95f14ddae

### Changes

- Integrated React Icons to display a hamburger menu icon and a close icon, added it to package.json
- Introduced a state to manage the open/close status of the mobile navigation menu.
- Added a button to toggle between the hamburger and close icons.
- Kept the account status display outside of the hamburger menu for visibility on all screen sizes.
- Wrapped the navigation links in a collapsible section for mobile screens, only displaying them when the menu is open.
- Ensured a responsive design where navigation links are displayed on larger screens and hidden on mobile.